### PR TITLE
Rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Flow Status Webpack Plugin
 
 [![npm version](https://img.shields.io/npm/v/flow-status-webpack-plugin.svg?style=flat-square)](https://www.npmjs.com/package/flow-status-webpack-plugin) [![npm downloads](https://img.shields.io/npm/dm/flow-status-webpack-plugin.svg?style=flat-square)](https://www.npmjs.com/package/flow-status-webpack-plugin)
 
-This [webpack](http://webpack.github.io/) plugin will start a [Flow](http://flowtype.org/) server and run `flow status` on each webpack build. Still experimental.
+This [webpack](http://webpack.github.io/) plugin will automatically start a [Flow](http://flowtype.org/) server (or restart if one is running) when webpack starts up, and run `flow status` after each webpack build. Still experimental.
 
 If you have any idea on how to get it better, you're welcome to contribute!
 
@@ -19,7 +19,7 @@ Installation
 Usage
 -----
 
-```
+```js
 var FlowStatusWebpackPlugin = require('flow-status-webpack-plugin');
 
 module.exports = {
@@ -41,16 +41,16 @@ or, in case of some error:
 Configuration
 -------------
 
-In case you have [Flow Interfaces](http://flowtype.org/docs/third-party.html#_) and you're not using a `.flowconfig` file, you need to specify a path to your interfaces directory, otherwise flow will not be able to identify (and use) those interfaces.
+If you want to pass additional command-line arguments to `flow start`, you can pass a `flowArgs` option to the plugin:
 
-```
+```js
 var FlowStatusWebpackPlugin = require('flow-status-webpack-plugin');
 
 module.exports = {
     ...
     plugins: [
         new FlowStatusWebpackPlugin({
-            interfacesPath: 'path/to/interfaces/directory'
+            flowArgs: '--lib path/to/interfaces/directory'
         })
     ]
 }

--- a/index.js
+++ b/index.js
@@ -2,45 +2,63 @@ const colors = require('colors');
 const shell = require('shelljs');
 
 function FlowStatusWebpackPlugin(options) {
-    const interfaces = options && options.interfacesPath ? ' --lib ' + options.interfacesPath : '';
-
-    // Developer may change some interface configuration between each
-    // file save. To avoid any configuration not being properly sent
-    // over to Flow server, we should stop it and start it again.
-    shell.exec('flow stop', {silent: true}, () => {
-        shell.exec('flow start' + interfaces, {silent: true}, (code) => {
-            this.flow_server_running = code === 0;
-        });
-    });
+    this.options = options || {};
 }
 
 FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
-    var _this = this;
+    const options = this.options;
+    const flowArgs = options.flowArgs || '';
 
-    // When Webpack compilation is done, we should run Flow Status.
-    compiler.plugin('done', function() {
+    function startFlow(cb) {
+        shell.exec('flow stop', () => {
+            shell.exec('flow start ' + flowArgs, () => cb());
+        });
+    }
 
-        // For now it's a week test, but since this plugin is not handling
-        // all kind of errors for now, it will work.
-        if (_this.flow_server_running) {
+    var firstRun = true;
+    function startFlowIfFirstRun(compiler, cb) {
+        if (firstRun) {
+            firstRun = false;
+            startFlow(cb);
+        }
+        else {
+            cb();
+        }
+    }
 
-            shell.exec('flow status', {silent: true}, (code, stdout) => {
+    // restart flow if interfacesPath was provided regardless of whether webpack is in normal or watch mode
+    compiler.plugin('run', startFlowIfFirstRun);
+    compiler.plugin('watch-run', startFlowIfFirstRun);
+
+    var waitingForFlow = false;
+
+    function flowStatus() {
+        if (!waitingForFlow) {
+            waitingForFlow = true;
+
+            // this will start a flow server if it was not running
+            shell.exec('flow status --color always', {silent: true}, (code, stdout, stderr) => {
                 const hasErrors = code !== 0;
 
                 if (hasErrors) {
                     console.log('\n----------------'.red);
                     console.log('Flow has errors!');
                     console.log('----------------\n'.red);
-                    console.log(stdout.red);
                 } else {
                     console.log('\n-----------------------------'.green);
                     console.log('Everything is fine with Flow!');
                     console.log('-----------------------------\n'.green);
-                    console.log(stdout.green);
                 }
+                console.log(stdout);
+                console.error(stderr);
+
+                waitingForFlow = false;
             });
         }
-    });
+    }
+
+    // When Webpack compilation is done, we should run Flow Status.
+    compiler.plugin('done', flowStatus);
 };
 
 module.exports = FlowStatusWebpackPlugin;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
   "name": "flow-status-webpack-plugin",
   "version": "0.1.0",
-  "author": {
-    "email": "dgodurli@gmail",
-    "name": "Diego Durli",
-    "url": "https://github.com/diegodurli"
-  },
+  "author": "Diego Durli <dgodurli@gmail> (https://github.com/diegodurli)",
   "dependencies": {
     "colors": "^1.1.2",
     "shelljs": "^0.6.0"
@@ -20,11 +16,18 @@
   "license": "MIT",
   "main": "index.js",
   "maintainers": [
-    {
-      "name": "diegodurli",
-      "email": "dgodurli@gmail.com"
-    }
+    "diegodurli <dgodurli@gmail.com>"
   ],
   "optionalDependencies": {},
-  "readmeFilename": "README.md"
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diegodurli/flow-status-webpack-plugin.git"
+  },
+  "bugs": {
+    "url": "https://github.com/diegodurli/flow-status-webpack-plugin/issues"
+  },
+  "homepage": "https://github.com/diegodurli/flow-status-webpack-plugin#readme"
 }


### PR DESCRIPTION
Thanks for this plugin!

This fork has various improvements:
- Doesn't restart the flow server in the `FlowStatusPlugin` constructor.  This is a very unexpected side effect.  If a config script constructs a `FlowStatusPlugin` but for whatever reason decides not to include it in the exported webpack config, the developer would not want any side effects to occur.  (Side effects in constructors are a [well-documented antipattern](http://blog.millermedeiros.com/constructors-should-not-cause-side-effects/)) 
- Uses `flowArgs` option instead of `interfacesPath` option -- use can instead pass `--lib path/to/interfaces` along with any other args they want (I updated the example in the README)
- Runs `flow status` even if flow server was started externally
- Prints `flow stop` and `flow start` output so user can see what's going on
- Avoids rerunning `flow status` if webpack rebuilds before last `flow status` finishes
- Prints Flow output with its nice `--color always` formatting
