### PR TITLE
add restartFlow option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ module.exports = {
 }
 ```
 
+If you don't want the plugin to automatically restart any running Flow server, pass `restartFlow: false`:
+
+```js
+var FlowStatusWebpackPlugin = require('flow-status-webpack-plugin');
+
+module.exports = {
+    ...
+    plugins: [
+        new FlowStatusWebpackPlugin({
+            restartFlow: false
+        })
+    ]
+}
+```
+
+
 License
 -------
 This plugin is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/index.js
+++ b/index.js
@@ -10,9 +10,14 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
     const flowArgs = options.flowArgs || '';
 
     function startFlow(cb) {
-        shell.exec('flow stop', () => {
+        if (options.restartFlow === false) {
             shell.exec('flow start ' + flowArgs, () => cb());
-        });
+        }
+        else {
+            shell.exec('flow stop', () => {
+                shell.exec('flow start ' + flowArgs, () => cb());
+            });
+        }
     }
 
     var firstRun = true;


### PR DESCRIPTION
Now if you pass `restartFlow: false`, it won't restart the Flow server.  This is helpful for me since I'm running multiple webpack-dev-servers in the same project directory.
