### PR TITLE
When using 'restartFlow: false', need to 'flow check'; not 'flow start'

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
 
     function startFlow(cb) {
         if (options.restartFlow === false) {
-            shell.exec(flow + ' start ' + flowArgs, cb);
+            shell.exec(flow + ' check ' + flowArgs, cb);
         } else {
             shell.exec(flow + ' stop', function() {
                 shell.exec(flow + ' start ' + flowArgs, cb);


### PR DESCRIPTION
If I want to keep a flow service running, you provide the restartFlow option to set to false. That is sa-weet! Thank you! However, on my version of flow (0.25.0), the flow command to run a flow check is..., well: flow check. Running flow start on an already started flow (0.25.0 at least) service causes bad things to happen.
