### PR TITLE
Adds quiet success option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ module.exports = {
 }
 ```
 
+If you don't want the plugin to display a message on success, pass
+`quietSuccess: true`:
+
+```js
+var FlowStatusWebpackPlugin = require('flow-status-webpack-plugin');
+
+module.exports = {
+    ...
+    plugins: [
+        new FlowStatusWebpackPlugin({
+            quietSuccess: true
+        })
+    ]
+}
+```
+
 License
 -------
 This plugin is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/index.js
+++ b/index.js
@@ -49,12 +49,14 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
                     console.log('\n----------------'.red);
                     console.log('Flow has errors!');
                     console.log('----------------\n'.red);
-                } else {
+                } else if (options.quietSuccess !== true) {
                     console.log('\n-----------------------------'.green);
                     console.log('Everything is fine with Flow!');
                     console.log('-----------------------------\n'.green);
                 }
-                console.log(stdout);
+                if (options.quietSuccess !== true || hasErrors) {
+                    console.log(stdout);
+                }
                 console.error(stderr);
 
                 waitingForFlow = false;


### PR DESCRIPTION
Adds an option to suppress the terminal output (standard out and success banner) when Flow reports no errors.
