### PR TITLE
Add option to fail the build in case of errors; Re-style to js standard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Flow Status Webpack Plugin
 ==========================
 
-[![npm version](https://img.shields.io/npm/v/flow-status-webpack-plugin.svg?style=flat-square)](https://www.npmjs.com/package/flow-status-webpack-plugin) [![npm downloads](https://img.shields.io/npm/dm/flow-status-webpack-plugin.svg?style=flat-square)](https://www.npmjs.com/package/flow-status-webpack-plugin)
-
 This [webpack](http://webpack.github.io/) plugin will automatically start a [Flow](http://flowtype.org/) server (or restart if one is running) when webpack starts up, and run `flow status` after each webpack build. Still experimental.
 
 If you have any idea on how to get it better, you're welcome to contribute!
@@ -29,14 +27,6 @@ module.exports = {
     ]
 }
 ```
-
-It will generate an output like this:
-
-![Flow has no errors](http://i.imgur.com/GX2xg8J.png?1)
-
-or, in case of some error:
-
-![Flow has errors](http://i.imgur.com/4cnu50c.png?1)
 
 Configuration
 -------------
@@ -81,22 +71,6 @@ module.exports = {
     plugins: [
         new FlowStatusWebpackPlugin({
             binaryPath: '/path/to/your/flow/installation'
-        })
-    ]
-}
-```
-
-If you don't want the plugin to display a message on success, pass
-`quietSuccess: true`:
-
-```js
-var FlowStatusWebpackPlugin = require('flow-status-webpack-plugin');
-
-module.exports = {
-    ...
-    plugins: [
-        new FlowStatusWebpackPlugin({
-            quietSuccess: true
         })
     ]
 }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ module.exports = {
 }
 ```
 
+If you want the plugin to fail the build if the code doesn't type check, pass `failOnError = true`, and include the `NoErrorsPlugin`:
+```js
+var FlowStatusWebpackPlugin = require('flow-status-webpack-plugin');
+
+module.exports = {
+    ...
+    plugins: [
+        new webpack.NoErrorsPlugin(),
+        new FlowStatusWebpackPlugin({
+            failOnError: true
+        })
+    ]
+}
+```
+
+
 License
 -------
 This plugin is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var colors = require('colors');
 var shell = require('shelljs');
 
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
   var options = this.options;
   var flowArgs = options.flowArgs || '';
   var flow = options.binaryPath || 'flow';
+  var failOnError = options.failOnError || false;
   var firstRun = true;
   var waitingForFlow = false;
 
@@ -79,7 +80,9 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
   // If there are flow errors, fail the build before compilation starts.
   compiler.plugin('compilation', function (compilation) {
     if (flowError) {
-      compilation.errors.push(flowError);
+      if (failOnError === true) {
+        compilation.errors.push(flowError);
+      }
       flowError = null;
     }
   });

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
       // this will start a flow server if it was not running
       shell.exec(flow + ' status --color always', {silent: true}, function(code, stdout, stderr) {
         var hasErrors = code !== 0;
-        cb = hasErrors ? errorCb : successCb
+        var cb = hasErrors ? errorCb : successCb
         waitingForFlow = false;
 
         if (isFunction(cb)) {

--- a/index.js
+++ b/index.js
@@ -63,6 +63,12 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
         cb()
       }, function error (stdout) {
         flowError = new Error(stdout)
+        // Here we don't pass error to callback because
+        // webpack-dev-middleware would just throw it
+        // and cause webpack dev server to exit with
+        // an error status code. Obviously, having to restart
+        // the development webpack server after every flow
+        // check error would be too annoying.
         cb()
       })
     })

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.5",
   "author": "Diego Durli <dgodurli@gmail> (https://github.com/diegodurli)",
   "dependencies": {
-    "colors": "^1.1.2",
     "shelljs": "^0.6.0"
   },
   "description": "Run Flow Status on each Webpack build.",


### PR DESCRIPTION
First, I would like to apologize for the fact that this pull request contains whitespace changes - I initially re-formatted the code to standard style. If nothing else, it makes reviewing this pull request harder. If you want, I can go back and undo those changes while maintaining the new code.

A couple of notes:
- We can think about just replicating what NoErrorsPlugin does, so that it isn't required for failing the build. But I'm not sure about that, as it would be literally copy-pasting code that exists as webpack core functionality.
- I don't like the fact that the build will fail only after webpack does the compilation - meaning, NoErrorsPlugin will cancel the build in 'should-emit' phase, by returning false. I didn't find a way
  to short-circuit the compile without some other drawbacks - e.g. crashing the dev server.
