### PR TITLE
root path support

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,10 +60,11 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
         onSuccess(stdout);
 
         cb();
-      }, function error(stdout) {
-        onError(stdout);
+      }, function error(stdout,stderr) {
 
-        flowError = new Error(stdout);
+        onError(stdout,stderr);
+
+        flowError = new Error(stdout + '\n' + stderr);
         // Here we don't pass error to callback because
         // webpack-dev-middleware would just throw it
         // and cause webpack dev server to exit with

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
   var options = this.options;
   var flowArgs = options.flowArgs || '';
   var flow = options.binaryPath || 'flow';
+  var root = options.root || '';
   var failOnError = options.failOnError || false;
   var onSuccess = options.onSuccess || noop;
   var onError = options.onError || noop;
@@ -20,8 +21,8 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
     if (options.restartFlow === false) {
       cb();
     } else {
-      shell.exec(flow + ' stop', {silent: true}, function() {
-        shell.exec(flow + ' start ' + flowArgs, {silent: true}, cb);
+      shell.exec(flow + ' stop ' + root, {silent: true}, function() {
+        shell.exec(flow + ' start ' + flowArgs + ' ' + root, {silent: true}, cb);
       });
     }
   }
@@ -41,7 +42,7 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
       waitingForFlow = true;
 
       // this will start a flow server if it was not running
-      shell.exec(flow + ' status --color always', {silent: true}, function(code, stdout, stderr) {
+      shell.exec(flow + ' status --color always '+ root, {silent: true}, function(code, stdout, stderr) {
         var hasErrors = code !== 0;
         var cb = hasErrors ? errorCb : successCb;
         waitingForFlow = false;


### PR DESCRIPTION
It was impossible to set a custom root path.

I was unable to pass the root as an extra argument because the same root will be needed from, "flow start", "flow stop" and "flow status" and at the moment the arguments are only applied to "flow start"

I did this change because my application needed to have a root path different from the path containing the .flowconfig