### PR TITLE
Update to use webpack 4 .hooks API

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,11 +74,11 @@ FlowStatusWebpackPlugin.prototype.apply = function(compiler) {
     })
   }
 
-  compiler.plugin('run', checkItWreckIt);
-  compiler.plugin('watch-run', checkItWreckIt);
+  compiler.hooks.run.tapAsync('flow-status-webpack-plugin', checkItWreckIt);
+  compiler.hooks.watchRun.tapAsync('flow-status-webpack-plugin', checkItWreckIt);
 
   // If there are flow errors, fail the build before compilation starts.
-  compiler.plugin('compilation', function (compilation) {
+  compiler.hooks.compilation.tap('flow-status-webpack-plugin', function (compilation) {
     if (flowError) {
       if (failOnError === true) {
         compilation.errors.push(flowError);


### PR DESCRIPTION
Webpack 4 uses a different plugin API than previous versions (https://github.com/webpack/webpack/issues/6568) 

This PR updates the plugin to remove the deprecation warning and use the new API (https://github.com/webpack/tapable)